### PR TITLE
remove trailing paren in link to indieweb

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,10 +48,8 @@
 	</div>
 	<footer class="site-footer" role="contentinfo">
 <p>
-	Built with <a href="https://github.com/miklb/jekyll-indieweb">Jekyll</a> on <a href="https://indiewebcamp.com)
-">IndieWeb principles</a>
+	Built with <a href="https://github.com/miklb/jekyll-indieweb">Jekyll</a> on <a href="https://indiewebcamp.com">IndieWeb principles</a>
 </p>
-
 	</footer>
 </body>
 


### PR DESCRIPTION
fixing footer link to indieweb site by removing paren