### PR TITLE
fix url protocol used so css styles don't break

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,9 +9,9 @@
 	<title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
 	<meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-	<link rel="stylesheet" href= "{{ site.github.url }}/css/main.css">
-	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.github.url | prepend: site.url }}">
-	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.github.url | prepend: site.url }}">
+	<link rel="stylesheet" href= "{{ site.github.url | replace: 'http://', 'https://' }}/css/main.css">
+	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.github.url | replace: 'http://', 'https://' }}">
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.github.url | replace: 'http://', 'https://' }}">
 	{% if site.webmentions %}
 	<link rel="webmention" href="https://webmention.herokuapp.com/api/webmention" />
 	{% endif %}


### PR DESCRIPTION
With site.github.url returning http instead of https, I changed the liquid tags used in the link tags in head, sort of along the lines suggested by @gauntface in this [issue comment](https://github.com/github/pages-gem/issues/238#issuecomment-206964532)
